### PR TITLE
Rename conflicted not published folder/file on creating/uploading

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 - Enh #178: Use new content state service
 - Fix #180: Use icon `fa-unlock` for public files
 - Fix #184: Display only published content files in the folder "Files from the stream"
+- Fix #186: Rename conflicted not published folder/file on creating/uploading
 
 0.16.1 - May 1, 2023
 --------------------

--- a/models/File.php
+++ b/models/File.php
@@ -496,4 +496,17 @@ class File extends FileSystemItem
         ]);
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function renameConflicted(): bool
+    {
+        if ($this->isNewRecord) {
+            return false;
+        }
+
+        $this->baseFile->file_name = 'conflict' . $this->baseFile->id . '-' . $this->baseFile->file_name;
+
+        return $this->baseFile->save();
+    }
 }

--- a/models/FileSystemItem.php
+++ b/models/FileSystemItem.php
@@ -81,6 +81,13 @@ abstract class FileSystemItem extends ContentActiveRecord implements ItemInterfa
     abstract public function getDeleteVersionUrl(int $versionId): ?string;
 
     /**
+     * Rename a conflicted Item with same name
+     *
+     * @return bool
+     */
+    abstract public function renameConflicted(): bool;
+
+    /**
      * @inheritdoc
      */
     public function attributeLabels()


### PR DESCRIPTION
Issue: https://github.com/humhub/humhub/issues/6433#issuecomment-1645404539

> > In the case of the File module you are right.
> > Probably we should change the handling here. So if a file is in status Pending/Soft Deletion and in the meantime a new file with the same filename is uploaded, we could also rename the deleted file e.g. from "test.doc" to "conflict[fileid]-test.doc". (Same for other modules)
> > This would also solves some other problems (e.g. OnlyOffice module [ONLYOFFICE/onlyoffice-humhub#100](https://github.com/ONLYOFFICE/onlyoffice-humhub/pull/100))
> 
> Ok, as I understood we should modify **core** code, (not CFiles module):
> 
> * If we new `File` is uploaded with same name and its `ContentActiveRecord` is soft deleted then we should rename to `conflict[fileid]-test.doc`, (fileid - is ID of the soft deleted File, right?)
> * otherwise do as now.
> 
> Should I create a separate issue for this or can I start to implement it here?

No. as I understood, the CFiles module has implemented a special handling here.
Specifically, when a file is marked as `Deleted` it get the status `Published` again if they have the same filename (`CFiles.Title`). 

e.g. https://github.com/humhub/cfiles/blob/master/controllers/EditController.php#L52

Instead of restoring the file/folder here. We should rename the soft deleted file/folder and create a fresh record as normal. 