### PR TITLE
Fix: Avoid UnknownPropertyException in validation error response

### DIFF
--- a/actions/UploadAction.php
+++ b/actions/UploadAction.php
@@ -44,11 +44,11 @@ class UploadAction extends \humhub\modules\file\actions\UploadAction
 
         $file = $folder->addUploadedFile($uploadedFile);
 
-        if($file->hasErrors()) {
+        if ($file->hasErrors()) {
             return $this->getValidationErrorResponse($file);
         }
 
-        if($file->baseFile->hasErrors()) {
+        if ($file->baseFile->hasErrors()) {
             return $this->getErrorResponse($file->baseFile);
         }
 
@@ -57,17 +57,17 @@ class UploadAction extends \humhub\modules\file\actions\UploadAction
 
     protected function getValidationErrorResponse(FileSystemItem $file)
     {
-        $errorMessage = Yii::t('FileModule.actions_UploadAction', 'File {fileName} could not be uploaded!', ['fileName' => $file->baseFile->name]);
+        $errorMessage = Yii::t('FileModule.actions_UploadAction', 'File {fileName} could not be uploaded!', ['fileName' => $file->baseFile->name ?? '']);
 
-        if(!empty($file->hasErrors())) {
+        if (!empty($file->hasErrors())) {
             $errorMessage = $file->getErrorSummary(false);
         }
 
         return [
             'error' => true,
             'errors' => $errorMessage,
-            'name' => $file->baseFile->name,
-            'size' => $file->baseFile->size
+            'name' => $file->baseFile->name ?? '',
+            'size' => $file->baseFile->size ?? '',
         ];
     }
 }

--- a/actions/UploadZipAction.php
+++ b/actions/UploadZipAction.php
@@ -28,7 +28,7 @@ class UploadZipAction extends UploadAction
         $zip = new ZipExtractor();
         $file = $zip->extract($this->controller->getCurrentFolder(), $uploadedFile);
 
-        if($file->hasErrors()) {
+        if ($file->hasErrors()) {
             return $this->getValidationErrorResponse($file);
         }
 
@@ -37,7 +37,7 @@ class UploadZipAction extends UploadAction
 
     protected function getValidationErrorResponse(FileSystemItem $file)
     {
-        $errorMessage = Yii::t('FileModule.actions_UploadAction', 'File {fileName} could not be uploaded!', ['fileName' => $file->baseFile->name]);
+        $errorMessage = Yii::t('FileModule.actions_UploadAction', 'File {fileName} could not be uploaded!', ['fileName' => $file->baseFile->name ?? '']);
 
         if (!empty($file->hasErrors())) {
             $errorMessage = array_values($file->getErrors())[0];
@@ -46,8 +46,8 @@ class UploadZipAction extends UploadAction
         return [
             'error' => true,
             'errors' => $errorMessage,
-            'name' => $file->baseFile->name,
-            'size' => $file->baseFile->size
+            'name' => $file->baseFile->name ?? '',
+            'size' => $file->baseFile->size ?? '',
         ];
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
 - Fix #184: Display only published content files in the folder "Files from the stream"
 - Fix #186: Rename conflicted not published folder/file on creating/uploading
 - Fix #189: Initialize module content class
-- Fix: Avoid UnknownPropertyException in validation error response
+- Fix #191: Avoid UnknownPropertyException in validation error response
 
 0.16.1 - May 1, 2023
 --------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 - Fix #184: Display only published content files in the folder "Files from the stream"
 - Fix #186: Rename conflicted not published folder/file on creating/uploading
 - Fix #189: Initialize module content class
+- Fix: Avoid UnknownPropertyException in validation error response
 
 0.16.1 - May 1, 2023
 --------------------
@@ -29,25 +30,22 @@ Changelog
 
 0.14.3 - Unreleased
 --------------------
-- Enh #152: Improve File listing layout 
+- Enh #152: Improve File listing layout
 
 0.14.2 - December 15, 2021
 --------------------------
 - Fix #149: Fix error on context menu for files from stream
-
 
 0.14.1 - December 7, 2021
 -------------------------
 - Fix #146: Update content last editor and date after save base File
 - Enh #127: Improve context menu with items from wall stream entry
 
-
 0.14.0 - November 26, 2021
 --------------------------
 - Enh #83: Enable paste/upload files from clipboard
 - Enh #100: Add context menu on hover
 - Enh #121: File versioning
-
 
 0.13.2 - Unreleased
 -----------------------
@@ -59,14 +57,12 @@ Changelog
 - Enh #133: Factorize duplicated code
 - Enh #140: Use widget ContentVisibiltySelect
 
-
 0.13.1 - July 29, 2021
 -----------------------
 - Enh #114: Fix for PHP8 - Deprecate required parameters after optional parameters
 - Fix #117: CLI error when no REST module is installed
 - Fix: Race condition on newly created files (import vs. oo)
 - Enh: Updated translations
-
 
 0.13.0 - April 9, 2021
 ----------------------
@@ -81,69 +77,58 @@ Changelog
 
 0.12.0 - November 4, 2020
 --------------------------
-- Enh #93: Wall Stream Layout Migration for HumHub 1.7+ 
+- Enh #93: Wall Stream Layout Migration for HumHub 1.7+
 
 0.11.20 - November 4, 2020
 ---------------------------
 - Fix #87: ZIP Upload broken due legency ImageConverter usage
-- Fix #74: Remove Temp Directory recursively in cleanup() 
+- Fix #74: Remove Temp Directory recursively in cleanup()
 - Enh #94: Implement Download Counter
 
 0.11.18 - December 4, 2019
 ---------------------------
 - Fix: Social acitivites for virtual (Files from stream and root) folders
 
-
 0.11.18 - December 4, 2019
 ---------------------------
 - Fix: Social acitivites for virtual (Files from stream and root) folders
-
 
 0.11.17 - June 27, 2019
 ---------------------------
 - Enh: Updated translations
 - Enh: Updated docs
 
-
 0.11.16 - October 10, 2018
 ---------------------------
 - Fix: Imported file visibility private
-
 
 0.11.15 - October 2, 2018
 ---------------------------
 - Fix: Imported file visibility private instead of public
 
-
 0.11.14 - September 18, 2018
 ---------------------------
 - Fix: getSearchAttributes() on items without editor or creator fails
-
 
 0.11.13 - July 26, 2018
 ---------------------------
 - Fix: Edit/Delete of own files without ManageFiles permission not working
 
-
 0.11.12 - July 2, 2018
 ---------------------------
 - Fix: PHP 7.2 compatibility issues
-
 
 0.11.11 - April 27, 2018
 ---------------------------
 - Fix: Profile files can't be managed
 
-
 0.11.10 - April 25, 2018
 ---------------------------
 - Fix: Yii 2.0.14 compatibility (https://github.com/yiisoft/yii2/issues/15875)
 
-
 0.11.9 - December 20, 2017
 ---------------------------
 - Enh: Updated translations
-
 
 0.11.7 - December 12, 2017
 ---------------------------
@@ -151,27 +136,22 @@ Changelog
 - Enh: Default sorting configuration
 - Enh: Remember user sort settings
 
-
 0.11.6 - October 27, 2017
 ---------------------------
 - Enh: Added upload behaviour settings (Index/Replace) in module config
 
-
 0.11.5 - October 22, 2017
 ---------------------------
 - Fix: Temporary files deletion on ZIP creation
-
 
 0.11.4 - October 13, 2017
 ---------------------------
 - Fix: Missing WallEntry layout for search results
 - Enh: Updated translations
 
-
 0.11.3 - September 22, 2017
 ---------------------------
 - Fix: Fixed mixed permissions check
-
 
 0.11.0 - September 4, 2017
 ---------------------------


### PR DESCRIPTION
Prevents the following error message and should allow `getValidationErrorResponse()` to return a proper response instead of throwing an error.

```
yii\base\UnknownPropertyException: Getting unknown property:
humhub\modules\cfiles\models\Folder::baseFile in
/var/www/protected/vendor/yiisoft/yii2/base/Component.php:154
Stack trace:
#0
/var/www/protected/vendor/yiisoft/yii2/db/BaseActiveRecord.php(296):
yii\base\Component->__get('baseFile')
#1
/var/www/protected/humhub/modules/content/components/ContentActiveRecord.php(210):
yii\db\BaseActiveRecord->__get('baseFile')
#2
/var/www/protected/modules/cfiles/actions/UploadZipAction.php(40):
humhub\modules\content\components\ContentActiveRecord->__get('baseFile')
#3
/var/www/protected/modules/cfiles/actions/UploadZipAction.php(32):
humhub\modules\cfiles\actions\UploadZipAction->getValidationErrorResponse(Object(humhub\modules\cfiles\models\Folder))
#4
/var/www/protected/humhub/modules/file/actions/UploadAction.php(72):
humhub\modules\cfiles\actions\UploadZipAction->handleFileUpload(Object(yii\web\UploadedFile),
false)
#5
/var/www/protected/modules/cfiles/actions/UploadAction.php(36):
humhub\modules\file\actions\UploadAction->run()
#6 [internal function]:
humhub\modules\cfiles\actions\UploadAction->run()
#7
/var/www/protected/vendor/yiisoft/yii2/base/Action.php(93):
call_user_func_array(Array, Array)
#8
/var/www/protected/vendor/yiisoft/yii2/base/Controller.php(178):
yii\base\Action->runWithParams(Array)
#9
/var/www/protected/vendor/yiisoft/yii2/base/Module.php(552):
yii\base\Controller->runAction('upload', Array)
#10
/var/www/protected/vendor/yiisoft/yii2/web/Application.php(103):
yii\base\Module->runAction('cfiles/zip/uplo...', Array)
#11
/var/www/protected/vendor/yiisoft/yii2/base/Application.php(384):
yii\web\Application->handleRequest(Object(humhub\components\Request))
#12
/var/www/index.php(27)
```