### PR TITLE
Removing Redundancy - Two Ways to Manage Topics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 - Enh #232: Update Active Form for Bootstrap 5
 - Enh #234: Increase File description max characters from 255 to 1000
 - Enh #236: Reduce translation message categories
+- Enh #238: Removing Topics from Edit File modal
 
 0.16.6 - March 14, 2024
 -------------------------

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog
 - Enh #232: Update Active Form for Bootstrap 5
 - Enh #234: Increase File description max characters from 255 to 1000
 - Enh #236: Reduce translation message categories
-- Enh #238: Removing Topics from Edit File modal
+- Enh #239: Removing Topics from Edit File modal
 
 0.16.6 - March 14, 2024
 -------------------------

--- a/views/edit/modal_edit_file.php
+++ b/views/edit/modal_edit_file.php
@@ -2,7 +2,6 @@
 
 
 use humhub\modules\content\widgets\richtext\RichTextField;
-use humhub\modules\topic\widgets\TopicPicker;
 use humhub\modules\ui\form\widgets\ActiveForm;
 use humhub\modules\ui\form\widgets\ContentHiddenCheckbox;
 use humhub\modules\ui\form\widgets\ContentVisibilitySelect;
@@ -24,7 +23,6 @@ use humhub\widgets\ModalDialog;
 <div class="modal-body">
     <?= $form->field($file->baseFile, 'file_name')->textInput(['autofocus' => '']) ?>
     <?= $form->field($file, 'description')->widget(RichTextField::class) ?>
-    <?= $form->field($file, 'topics')->widget(TopicPicker::class, ['contentContainer' => $file->content->container])->label(false) ?>
     <?= $form->field($file, 'visibility')->widget(ContentVisibilitySelect::class, ['readonly' => $file->parentFolder->content->isPrivate()]) ?>
     <?= $form->field($file, 'hidden')->widget(ContentHiddenCheckbox::class, []) ?>
     <?= $form->field($file, 'download_count')->staticControl(['style' => 'display:inline']) ?>


### PR DESCRIPTION
In case we agree that it's better to follow "established" user flow/UX for Topics. And also if this is the correct implementation. I removed the topics field from the HTML form and the corresponding TopicPicker class from the namespace imports.

https://github.com/humhub/cfiles/issues/238